### PR TITLE
Implementing callable tasks and executor

### DIFF
--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
@@ -1,0 +1,237 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import io.narayana.lra.arquillian.Deployer;
+import io.narayana.lra.arquillian.TestBase;
+import io.narayana.lra.arquillian.resource.LRAParticipant;
+import io.narayana.lra.client.NarayanaLRAClient;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+
+public class LRAAsyncIT extends TestBase {
+
+    private static final Logger log = Logger.getLogger(LRAAsyncIT.class);
+    private static final String SHOULD_NOT_BE_ASSOCIATED = "The narayana implementation (of the MP-LRA specification) still thinks that there is "
+            + "an active LRA associated with the current thread even though all LRAs should now be finished";
+    //from 1 to 8 tasks the test is successful, when 16 or more there are tests failures
+    private static final int NUMBER_OF_TASKS = 16;
+
+    @ArquillianResource
+    public URL baseURL;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Override
+    public void before() {
+        super.before();
+        log.info("Running test " + testName.getMethodName());
+    }
+    @Override
+    public void after() {
+        super.after();
+        executorService.shutdown();
+    }
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(LRAAsyncIT.class.getSimpleName(), LRAParticipant.class);
+    }
+
+    private ExecutorService executorService = Executors.newFixedThreadPool(20);
+
+    /**
+     * Invoke a resource method which in turn invokes other resources. The various
+     * resource invocations are called in new or existing LRAs. Various tests are
+     * performed to verify that the correct LRAs are used and the LRAs have the
+     * expected status (see the resource method for the detail).
+     */
+    @Test
+    public void testChainOfInvocations() {
+        NarayanaLRAClient lraClient = new NarayanaLRAClient();
+        Callable<URI> callableTask = () -> {
+
+
+                // Invoke a method which starts a transaction
+                // (note that the method LRAParticipant.CREATE_OR_CONTINUE_LRA also invokes
+                // other resource methods)
+                URI lra1 = invokeInTransaction(null, LRAParticipant.CREATE_OR_CONTINUE_LRA);
+                    lrasToAfterFinish.add(lra1);
+                    assertEquals("LRA should still be active. The identifier of the LRA was " + lra1, LRAStatus.Active,
+                            lraClient.getStatus(lra1));
+
+                    // end the LRA
+                    invokeInTransaction(lra1, LRAParticipant.END_EXISTING_LRA);
+
+
+                    return lraClient.getCurrent();
+
+        };
+
+        List<Callable<URI>> callableTasks = new ArrayList<>();
+        for(int i = 0; i< NUMBER_OF_TASKS; i++)
+            callableTasks.add(callableTask);
+
+        try {
+            List<Future<URI>> futures = executorService.invokeAll(callableTasks);
+            for( Future<URI> f : futures)
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, f.get());
+
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            fail("error in lra call");
+        }
+    }
+
+    /**
+     * test behaviour when multiple LRAs are active
+     */
+    @Test
+    public void testNoCurrent() {
+            NarayanaLRAClient lraClient = new NarayanaLRAClient();
+
+            URI lra1 = invokeInTransaction(null, LRAParticipant.START_NEW_LRA);
+
+                lrasToAfterFinish.add(lra1);
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+                URI lra2 = invokeInTransaction(null, LRAParticipant.START_NEW_LRA);
+                lrasToAfterFinish.add(lra2);
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+
+                invokeInTransaction(lra1, LRAParticipant.END_EXISTING_LRA);
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+                invokeInTransaction(lra2, LRAParticipant.END_EXISTING_LRA);
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+    }
+
+    /**
+     * Test that remote invocations can start and stop LRAs using the proprietary
+     * client API
+     */
+    @Test
+    public void testRemoteCurrent() {
+            NarayanaLRAClient lraClient = new NarayanaLRAClient();
+
+            URI lra1 = invokeInTransaction(null, LRAParticipant.CREATE_OR_CONTINUE_LRA2);
+                lrasToAfterFinish.add(lra1);
+                invokeInTransaction(lra1, LRAParticipant.END_EXISTING_LRA);
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+    }
+
+    /**
+     * JBTM-3223 Validate LRA behaviour when multiple LRA's are active on the same
+     * thread
+     *
+     * when multiple LRA's are active on the same thread that as one LRA finishes
+     * that: a) the next one is handled correctly b) creating another one still
+     * works fine
+     */
+    @Test
+    public void testCurrent() {
+            NarayanaLRAClient lraClient = new NarayanaLRAClient();
+
+            // start two LRAs on the current thread
+            URI lra1 = lraClient.startLRA("lra1");
+            lrasToAfterFinish.add(lra1);
+            assertEquals("lra1 is not associated with the current thread", lra1, lraClient.getCurrent());
+            URI lra2 = lraClient.startLRA("lra2");
+            lrasToAfterFinish.add(lra2);
+            assertEquals("lra2 is not associated with the current thread", lra2, lraClient.getCurrent());
+
+            // a) closing the current one should make the previous one active
+            lraClient.closeLRA(lra2);
+            assertEquals("closing the current LRA should have made the previous one active", lra1,
+                    lraClient.getCurrent());
+
+            // b) verify that creating another LRA still works fine
+            URI lra3 = lraClient.startLRA("lra3");
+            lrasToAfterFinish.add(lra3);
+            assertEquals("lra3 is not associated with the current thread", lra3, lraClient.getCurrent());
+
+            lraClient.closeLRA(lra3);
+            assertEquals("closing the current LRA (lra3) should have made the previous one (lra1) active", lra1,
+                    lraClient.getCurrent());
+
+            // check that closing the last LRA will leave none active
+            lraClient.closeLRA(lra1);
+            assertNull("all LRAs are closed so none should be associated with the calling thread",
+                    lraClient.getCurrent());
+
+            lraClient.close();
+    }
+
+    private URI invokeInTransaction(URI lra, String resourcePath) {
+
+            Response response = null;
+
+            try {
+                Invocation.Builder builder = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                        .path(LRAParticipant.RESOURCE_PATH).path(resourcePath).build()).request();
+
+                if (lra != null) {
+                    builder.header(LRA_HTTP_CONTEXT_HEADER, lra.toASCIIString());
+                }
+
+                response = builder.get();
+
+                assertTrue("This test expects that the invoked resource returns the identifier of the LRA "
+                        + "that was active during the invocation or an error message.", response.hasEntity());
+
+                String responseMessage = response.readEntity(String.class);
+
+                assertEquals(responseMessage, 200, response.getStatus());
+
+                return URI.create(responseMessage);
+            } finally {
+                if (response != null) {
+                    response.close();
+                }
+            }
+    }
+}


### PR DESCRIPTION
This PR is for testing LRA and your PR. I added an LRAAsyncIT test that fails when the constant NUMBER_OF_TASKS is =>16.

`09:38:46,287 ERROR [org.jboss.resteasy.core.providerfactory.DefaultExceptionMapper] (default task-9) RESTEASY002375: Error processing request POST /lra-coordinator/lra-coordinator/start - io.narayana.lra.coordinator.api.Coordinator.startLRA: org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException: io.narayana.lra.coordinator.api.Coordinator#startLRA rejected from bulkhead
	at io.smallrye.fault-tolerance@6.1.0//io.smallrye.faulttolerance.core.bulkhead.BulkheadBase.bulkheadRejected(BulkheadBase.java:17)
	at io.smallrye.fault-tolerance@6.1.0//io.smallrye.faulttolerance.core.bulkhead.SemaphoreBulkhead.doApply(SemaphoreBulkhead.java:47)`